### PR TITLE
Add clause when singer.decimal is null to prevent str()

### DIFF
--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -142,7 +142,10 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted, c
         elif isinstance(elem, uuid.UUID):
             row_to_persist += (str(elem),)
         elif property_format == 'singer.decimal':
-            row_to_persist += (str(elem),)
+            if elem is None:
+                row_to_persist += (elem,)
+            else:
+                row_to_persist += (str(elem),)
         else:
             row_to_persist += (elem,)
     rec = dict(zip(columns, row_to_persist))


### PR DESCRIPTION
When the value of a singer.decimal attribute is null, do not convert it to string