### PR TITLE
Fix for scenario where state LSN is equal to system max LSN

### DIFF
--- a/tap_mssql/sync_strategies/log_based.py
+++ b/tap_mssql/sync_strategies/log_based.py
@@ -237,7 +237,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
 
                 if lsn_from <= state_last_lsn:
                     LOGGER.info("The last lsn processed as per the state file %s, minimum available lsn for extract table %s, and the maximum lsn is %s.", state_last_lsn, lsn_from, lsn_to)
-                    if lsn_from == state_last_lsn:
+                    if lsn_to == state_last_lsn:
                         LOGGER.info("The last lsn processed as per the state file is equal to the max lsn available - no changes expected - state lsn will not be incremented")
                         from_lsn_expression = "{}".format(py_bin_to_mssql(state_last_lsn))
                     else:

--- a/tap_mssql/sync_strategies/log_based.py
+++ b/tap_mssql/sync_strategies/log_based.py
@@ -237,12 +237,17 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
 
                 if lsn_from <= state_last_lsn:
                     LOGGER.info("The last lsn processed as per the state file %s, minimum available lsn for extract table %s, and the maximum lsn is %s.", state_last_lsn, lsn_from, lsn_to)
+                    if lsn_from == state_last_lsn:
+                        LOGGER.info("The last lsn processed as per the state file is equal to the max lsn available - no changes expected - state lsn will not be incremented")
+                        from_lsn_expression = "{}".format(py_bin_to_mssql(state_last_lsn))
+                    else:
+                        from_lsn_expression = "sys.fn_cdc_increment_lsn({})".format(py_bin_to_mssql(state_last_lsn))
                 else:
                     raise Exception("Error {}.{}: CDC changes have expired, the minimum lsn is {}, the last processed lsn is {}. Recommend a full load as there may be missing data.".format(schema_name, table_name, lsn_from, state_last_lsn ))                
 
                 select_sql = """DECLARE @from_lsn binary (10), @to_lsn binary (10)
                     
-                                SET @from_lsn = sys.fn_cdc_increment_lsn({})
+                                SET @from_lsn = {}
                                 SET @to_lsn = {}
 
                                 SELECT {}
@@ -261,7 +266,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
                                     , __$operation _sdc_lsn_operation
                                 FROM cdc.fn_cdc_get_all_changes_{}(@from_lsn, @to_lsn, 'all')
                                 ORDER BY __$start_lsn, __$seqval, __$operation
-                                ;""".format(py_bin_to_mssql(state_last_lsn), py_bin_to_mssql(lsn_to), ",".join(escaped_columns), schema_table )
+                                ;""".format(from_lsn_expression, py_bin_to_mssql(lsn_to), ",".join(escaped_columns), schema_table )
 
                 params = {}
 


### PR DESCRIPTION
The code has been updated to cater for a scenario where the LSN value provided from state is equal to the max LSN for the database.

Previously the `sys.fn_cdc_increment_lsn({})` function was applied to the state value, such that new changes were fetched when performing a log-based sync.

However, if max = state then incrementing the state value leads to the tap requesting changes between a `from_lsn` value that is higher than the `to_lsn` value, which breaks the process.

The fix is to check the LSN value from state against the max value. The max value is set from this SQL

```sql
SELECT sys.fn_cdc_get_min_lsn ( '{}' ) lsn_from
                    , sys.fn_cdc_get_max_lsn () lsn_to
               ;
```

A Python variable called `lsn_to` contains the `sys.fn_cdc_get_max_lsn` for the system. If the value coming from state is the same as the max then the `fn_cdc_increment_lsn` function is not applied.

The extract SQL has had the function call removed and replaced with a generic `from_lsn_expression` variable. This variable:

- set to `fn_cdc_increment_lsn` if max <> state
- just set to `state_lsn` if max = state

An extra message is output to confirm that the max = state and thus no changes are expected. The query is run with equal from and to values, from which there should be no output.